### PR TITLE
fix: Google確認メタタグを<head>内に移動

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,10 @@
       "knowsAbout": ["自然言語処理", "NLP", "BERT", "SNSユーザの属性推定", "言語モデルの冗長性"]
     }
     </script>
+
+    <!-- Google Search Console 確認 -->
+    <meta name="google-site-verification" content="wZg_4a1fiUzLGpMWFa5pr4BoG8dhN48SeF0Jc65WklQ" />
 </head>
-<meta name="google-site-verification" content="wZg_4a1fiUzLGpMWFa5pr4BoG8dhN48SeF0Jc65WklQ" />
 <body>
     <header>
         <nav aria-label="メインナビゲーション">


### PR DESCRIPTION
## 問題

Google Search Console確認用メタタグが`</head>`の外に配置されており、Google側で「確認メタタグが見つかりませんでした」というエラーが発生していました。

## 修正内容

- メタタグを`<head>`セクション内（`</head>`の前）に移動
- コメントを追加して可読性を向上

## 変更ファイル

- `index.html`: Google確認メタタグの位置を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)